### PR TITLE
Add new method jalaaliYearLength and dayOfTheWeek

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports =
   , isValidJalaaliDate: isValidJalaaliDate
   , isLeapJalaaliYear: isLeapJalaaliYear
   , jalaaliMonthLength: jalaaliMonthLength
+  , jalaaliYearLength: jalaaliYearLength
   , jalCal: jalCal
   , j2d: j2d
   , d2j: d2j
@@ -64,6 +65,15 @@ function jalaaliMonthLength(jy, jm) {
   if (jm <= 11) return 30
   if (isLeapJalaaliYear(jy)) return 30
   return 29
+}
+
+/*
+  Number of days in year.
+*/
+function jalaaliYearLength(jy) {
+  var day = 336  
+  if (isLeapJalaaliYear(jy)) return day + 30
+  return day + 29
 }
 
 /*

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function jalaaliYearLength(jy) {
 /*
   Day of the week
 
-  @param jy Jalaali calendar year (-61 to 3177)
+  @param jy Jalaali calendar year (1 to 3177)
   @param jm Jalaali calendar month (1 to 12)
   @param jd Jalaali calendar day (1 to [29,30,31])
   @returns 0 to 6, 0 is first of week and 6 is end of week

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports =
   , isLeapJalaaliYear: isLeapJalaaliYear
   , jalaaliMonthLength: jalaaliMonthLength
   , jalaaliYearLength: jalaaliYearLength
+  , dayOfTheWeek: dayOfTheWeek
   , jalCal: jalCal
   , j2d: j2d
   , d2j: d2j
@@ -69,11 +70,36 @@ function jalaaliMonthLength(jy, jm) {
 
 /*
   Number of days in year.
+
+  @param jy Jalaali calendar year (-61 to 3177)
+  @returns year length
 */
 function jalaaliYearLength(jy) {
   var day = 336  
   if (isLeapJalaaliYear(jy)) return day + 30
   return day + 29
+}
+
+/*
+  Day of the week
+
+  @param jy Jalaali calendar year (-61 to 3177)
+  @param jm Jalaali calendar month (1 to 12)
+  @param jd Jalaali calendar day (1 to [29,30,31])
+  @returns 0 to 6, 0 is first of week and 6 is end of week
+*/
+function dayOfTheWeek(jy, jm, jd){  
+  var day = 0;
+  for (var i = 1; i < jy; i++)
+    day += jalaaliYearLength(i)
+  
+  for (var i = 1; i < jm; i++)
+    day += jalaaliMonthLength(jy, i)
+    
+  day += jd
+  day %= 7
+  if (day === 0 || day === 1) return day + 5
+  return day - 2  
 }
 
 /*

--- a/test.js
+++ b/test.js
@@ -78,3 +78,17 @@ describe('jalaaliYearLength', function () {
   })
 })
 
+describe('dayOfTheWeek', function () {
+  it('should return number of week index', function () {
+    j.dayOfTheWeek(1,1,1).should.be.exactly(6)
+    j.dayOfTheWeek(1,1,2).should.be.exactly(0)
+    j.dayOfTheWeek(1,2,1).should.be.exactly(2)
+    j.dayOfTheWeek(1,2,31).should.be.exactly(4)
+    j.dayOfTheWeek(1,2,31).should.be.exactly(4)
+    j.dayOfTheWeek(1,6,1).should.be.exactly(0)
+    j.dayOfTheWeek(1,7,1).should.be.exactly(3)
+    j.dayOfTheWeek(2,1,1).should.be.exactly(0)
+    j.dayOfTheWeek(1300,1,1).should.be.exactly(2)    
+    j.dayOfTheWeek(1398,8,9).should.be.exactly(5)     
+  })
+})

--- a/test.js
+++ b/test.js
@@ -64,3 +64,17 @@ describe('jalaaliMonthLength', function () {
     j.jalaaliMonthLength(1395, 12).should.be.exactly(30)
   })
 })
+
+describe('jalaaliYearLength', function () {
+  it('should return number of days in a year', function () {
+    j.jalaaliYearLength(1398).should.be.exactly(365)
+    j.jalaaliYearLength(1397).should.be.exactly(365)
+    j.jalaaliYearLength(1396).should.be.exactly(365)
+    j.jalaaliYearLength(1395).should.be.exactly(366)
+    j.jalaaliYearLength(1394).should.be.exactly(365)
+    j.jalaaliYearLength(1393).should.be.exactly(365)
+    j.jalaaliYearLength(1392).should.be.exactly(365)
+    j.jalaaliYearLength(1391).should.be.exactly(366)
+  })
+})
+


### PR DESCRIPTION
jalaaliYearLength for determine year length ex:
```javascript
jalaaliYearLength(1398) // 365
jalaaliYearLength(1395) // 366
```
dayOfTheWeek for determine day index in week ex:
```javascript
dayOfTheWeek(1398,8,4)  // 0 => شنبه
dayOfTheWeek(1398,8,5)  // 1 => یکشنبه
dayOfTheWeek(1398,8,6)  // 2 => دوشنبه
dayOfTheWeek(1398,8,7)  // 3 => سه شنبه
dayOfTheWeek(1398,8,8)  // 4 => چهارشنبه
dayOfTheWeek(1398,8,9)  // 5 => پنج شنبه
dayOfTheWeek(1398,8,10) // 6 => جمعه
dayOfTheWeek(1398,8,11) // 0 => شنبه
```
