### PR TITLE
Added a UMD build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+dist

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Then import it:
 var jalaali = require('jalaali-js')
 ```
 
+Or use a CDN:
+```
+<script src="https://cdn.jsdelivr.net/npm/jalaali-js/dist/jalaali.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jalaali-js/dist/jalaali.min.js"></script>
+
+<script src="https://unpkg.com/jalaali-js/dist/jalaali.js"></script>
+<script src="https://unpkg.com/jalaali-js/dist/jalaali.min.js"></script>
+```
+
 ## API
 
 ### toJalaali(gy, gm, gd)

--- a/build-umd.js
+++ b/build-umd.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const { execSync }  = require('child_process');
+process.env.path += require('path').delimiter + './node_modules/.bin';
+
+if (!fs.existsSync('dist')) fs.mkdirSync('dist');
+
+fs.writeFileSync('x.js', "module.exports = require('./index.js');");
+execSync('browserify x.js -s jalaali -o dist/jalaali.js');
+execSync('terser dist/jalaali.js -c -m -o dist/jalaali.min.js');
+fs.unlinkSync('x.js');

--- a/package.json
+++ b/package.json
@@ -24,10 +24,14 @@
   "homepage": "https://github.com/jalaali/jalaali-js",
   "devDependencies": {
     "mocha": "^6.2.1",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "browserify": "^16.5.2",
+    "terser": "^5.3.3"
   },
   "scripts": {
+    "prepare": "node build-umd.js",
     "bench": "node bench.js",
     "test": "mocha test.js"
-  }
+  },
+  "files": ["*"]
 }


### PR DESCRIPTION
Added a UMD build script to make it possible to use this package directly in the browser.

Currently that is not possible without a build step.
(for example look in [jsdeliver](https://cdn.jsdelivr.net/npm/jalaali-js/) or [unpkg](https://unpkg.com/browse/jalaali-js/) directories)

This pull request resolves the issue and if merged then the following code is valid:

```html
<script src="https://cdn.jsdelivr.net/npm/jalaali-js/dist/jalaali.js"></script>
<script src="https://cdn.jsdelivr.net/npm/jalaali-js/dist/jalaali.min.js"></script>

<script src="https://unpkg.com/jalaali-js/dist/jalaali.js"></script>
<script src="https://unpkg.com/jalaali-js/dist/jalaali.min.js"></script>

<script>
jalaali.toJalaali(2016, 4, 11) // { jy: 1395, jm: 1, jd: 23 }
</script>
```